### PR TITLE
Change Interpolation syntax to fix warnings

### DIFF
--- a/src/time/time.jl
+++ b/src/time/time.jl
@@ -153,7 +153,7 @@ The Julian Day in UT1.
 
 """
 function JD_UTCtoUT1(JD_UTC::Number, eop::Union{EOPData_IAU1980,EOPData_IAU2000A})
-	JD_UTCtoUT1(JD_UTC, eop.UT1_UTC[JD_UTC])
+	JD_UTCtoUT1(JD_UTC, eop.UT1_UTC(JD_UTC))
 end
 
 """
@@ -174,7 +174,7 @@ The Julian Day in UTC.
 
 """
 function JD_UT1toUTC(JD_UT1::Number, eop::Union{EOPData_IAU1980,EOPData_IAU2000A})
-	JD_UT1toUTC(JD_UT1, eop.UT1_UTC[JD_UT1])
+	JD_UT1toUTC(JD_UT1, eop.UT1_UTC(JD_UT1))
 end
 
 """

--- a/src/transformations/ecef_to_ecef.jl
+++ b/src/transformations/ecef_to_ecef.jl
@@ -128,8 +128,8 @@ function rECEFtoECEF(T::Type,
     # Get the EOP data related to the desired epoch.
     #
     # TODO: The difference is small, but should it be `JD_TT` or `JD_UTC`?
-    x_p = eop_data.x[JD_UTC]*pi/648000
-    y_p = eop_data.y[JD_UTC]*pi/648000
+    x_p = eop_data.x(JD_UTC)*pi/648000
+    y_p = eop_data.y(JD_UTC)*pi/648000
 
     # Return the rotation.
     rITRFtoPEF_fk5(T, x_p, y_p)

--- a/src/transformations/ecef_to_eci.jl
+++ b/src/transformations/ecef_to_eci.jl
@@ -220,10 +220,10 @@ function rECEFtoECI(T::Type,
     # Get the EOP data related to the desired epoch.
     #
     # TODO: The difference is small, but should it be `JD_TT` or `JD_UTC`?
-    x_p      = eop_data.x[JD_UTC]*pi/648000
-    y_p      = eop_data.y[JD_UTC]*pi/648000
-    δΔϵ_1980 = eop_data.dEps[JD_UTC]*pi/648000
-    δΔψ_1980 = eop_data.dPsi[JD_UTC]*pi/648000
+    x_p      = eop_data.x(JD_UTC)*pi/648000
+    y_p      = eop_data.y(JD_UTC)*pi/648000
+    δΔϵ_1980 = eop_data.dEps(JD_UTC)*pi/648000
+    δΔψ_1980 = eop_data.dPsi(JD_UTC)*pi/648000
 
     # Compute the rotation.
     rITRFtoGCRF_fk5(T, JD_UT1, JD_TT, x_p, y_p, δΔϵ_1980, δΔψ_1980)
@@ -246,8 +246,8 @@ function rECEFtoECI(T::Type,
     # Get the EOP data related to the desired epoch.
     #
     # TODO: The difference is small, but should it be `JD_TT` or `JD_UTC`?
-    x_p      = eop_data.x[JD_UTC]*pi/648000
-    y_p      = eop_data.y[JD_UTC]*pi/648000
+    x_p      = eop_data.x(JD_UTC)*pi/648000
+    y_p      = eop_data.y(JD_UTC)*pi/648000
 
     # Compute the rotation.
     rITRFtoGCRF_fk5(T, JD_UT1, JD_TT, x_p, y_p, 0, 0)
@@ -270,10 +270,10 @@ function rECEFtoECI(T::Type,
     # Get the EOP data related to the desired epoch.
     #
     # TODO: The difference is small, but should it be `JD_TT` or `JD_UTC`?
-    x_p      = eop_data.x[JD_UTC]*pi/648000
-    y_p      = eop_data.y[JD_UTC]*pi/648000
-    δΔϵ_1980 = eop_data.dEps[JD_UTC]*pi/648000
-    δΔψ_1980 = eop_data.dPsi[JD_UTC]*pi/648000
+    x_p      = eop_data.x(JD_UTC)*pi/648000
+    y_p      = eop_data.y(JD_UTC)*pi/648000
+    δΔϵ_1980 = eop_data.dEps(JD_UTC)*pi/648000
+    δΔψ_1980 = eop_data.dPsi(JD_UTC)*pi/648000
 
     # Compute the rotation.
     r_PEF_ITRF = rITRFtoPEF_fk5(T, x_p, y_p)
@@ -299,9 +299,9 @@ function rECEFtoECI(T::Type,
     # Get the EOP data related to the desired epoch.
     #
     # TODO: The difference is small, but should it be `JD_TT` or `JD_UTC`?
-    x_p      = eop_data.x[JD_UTC]*pi/648000
-    y_p      = eop_data.y[JD_UTC]*pi/648000
-    δΔψ_1980 = eop_data.dPsi[JD_UTC]*pi/648000
+    x_p      = eop_data.x(JD_UTC)*pi/648000
+    y_p      = eop_data.y(JD_UTC)*pi/648000
+    δΔψ_1980 = eop_data.dPsi(JD_UTC)*pi/648000
 
     # Compute the rotation.
     r_PEF_ITRF = rITRFtoPEF_fk5(T, x_p, y_p)
@@ -327,8 +327,8 @@ function rECEFtoECI(T::Type,
     # Get the EOP data related to the desired epoch.
     #
     # TODO: The difference is small, but should it be `JD_TT` or `JD_UTC`?
-    x_p      = eop_data.x[JD_UTC]*pi/648000
-    y_p      = eop_data.y[JD_UTC]*pi/648000
+    x_p      = eop_data.x(JD_UTC)*pi/648000
+    y_p      = eop_data.y(JD_UTC)*pi/648000
 
     # Compute the rotation.
     r_PEF_ITRF = rITRFtoPEF_fk5(T, x_p, y_p)
@@ -354,10 +354,10 @@ function rECEFtoECI(T::Type,
     # Get the EOP data related to the desired epoch.
     #
     # TODO: The difference is small, but should it be `JD_TT` or `JD_UTC`?
-    x_p      = eop_data.x[JD_UTC]*pi/648000
-    y_p      = eop_data.y[JD_UTC]*pi/648000
-    δΔϵ_1980 = eop_data.dEps[JD_UTC]*pi/648000
-    δΔψ_1980 = eop_data.dPsi[JD_UTC]*pi/648000
+    x_p      = eop_data.x(JD_UTC)*pi/648000
+    y_p      = eop_data.y(JD_UTC)*pi/648000
+    δΔϵ_1980 = eop_data.dEps(JD_UTC)*pi/648000
+    δΔψ_1980 = eop_data.dPsi(JD_UTC)*pi/648000
 
     # Compute the rotation.
     r_MOD_PEF  = rPEFtoMOD_fk5(T, JD_UT1, JD_TT, δΔϵ_1980, δΔψ_1980)
@@ -420,10 +420,10 @@ function rECEFtoECI(T::Type,
     # Get the EOP data related to the desired epoch.
     #
     # TODO: The difference is small, but should it be `JD_TT` or `JD_UTC`?
-    x_p      = eop_data.x[JD_UTC]*pi/648000
-    y_p      = eop_data.y[JD_UTC]*pi/648000
-    δΔϵ_1980 = eop_data.dEps[JD_UTC]*pi/648000
-    δΔψ_1980 = eop_data.dPsi[JD_UTC]*pi/648000
+    x_p      = eop_data.x(JD_UTC)*pi/648000
+    y_p      = eop_data.y(JD_UTC)*pi/648000
+    δΔϵ_1980 = eop_data.dEps(JD_UTC)*pi/648000
+    δΔψ_1980 = eop_data.dPsi(JD_UTC)*pi/648000
 
     # Compute the rotation.
     rPEFtoMOD_fk5(T, JD_UT1, JD_TT, δΔϵ_1980, δΔψ_1980)
@@ -446,9 +446,9 @@ function rECEFtoECI(T::Type,
     # Get the EOP data related to the desired epoch.
     #
     # TODO: The difference is small, but should it be `JD_TT` or `JD_UTC`?
-    x_p      = eop_data.x[JD_UTC]*pi/648000
-    y_p      = eop_data.y[JD_UTC]*pi/648000
-    δΔψ_1980 = eop_data.dPsi[JD_UTC]*pi/648000
+    x_p      = eop_data.x(JD_UTC)*pi/648000
+    y_p      = eop_data.y(JD_UTC)*pi/648000
+    δΔψ_1980 = eop_data.dPsi(JD_UTC)*pi/648000
 
     # Compute the rotation.
     rPEFtoTOD_fk5(T, JD_UT1, JD_TT, δΔψ_1980)

--- a/src/transformations/eci_to_eci.jl
+++ b/src/transformations/eci_to_eci.jl
@@ -238,8 +238,8 @@ function rECItoECI(T::Type,
     # Get the EOP data related to the desired epoch.
     #
     # TODO: The difference is small, but should it be `JD_TT` or `JD_UTC`?
-    δΔϵ_1980 = eop_data.dEps[JD_UTC]*pi/648000
-    δΔψ_1980 = eop_data.dPsi[JD_UTC]*pi/648000
+    δΔϵ_1980 = eop_data.dEps(JD_UTC)*pi/648000
+    δΔψ_1980 = eop_data.dPsi(JD_UTC)*pi/648000
 
     # In this case, we need to convert GCRF back to PEF and then convert to
     # J2000, which is the same conversion from PEF to GCRF **without** the EOP
@@ -305,8 +305,8 @@ function rECItoECI(T::Type,
     # Get the EOP data related to the desired epoch.
     #
     # TODO: The difference is small, but should it be `JD_TT` or `JD_UTC`?
-    δΔϵ_1980 = eop_data.dEps[JD_UTC]*pi/648000
-    δΔψ_1980 = eop_data.dPsi[JD_UTC]*pi/648000
+    δΔϵ_1980 = eop_data.dEps(JD_UTC)*pi/648000
+    δΔψ_1980 = eop_data.dPsi(JD_UTC)*pi/648000
 
     # Return the rotation.
     r_MOD_GCRF = rGCRFtoMOD_fk5(T, JD_TT)
@@ -340,8 +340,8 @@ function rECItoECI(T::Type,
     # Get the EOP data related to the desired epoch.
     #
     # TODO: The difference is small, but should it be `JD_TT` or `JD_UTC`?
-    δΔϵ_1980 = eop_data.dEps[JD_UTC]*pi/648000
-    δΔψ_1980 = eop_data.dPsi[JD_UTC]*pi/648000
+    δΔϵ_1980 = eop_data.dEps(JD_UTC)*pi/648000
+    δΔψ_1980 = eop_data.dPsi(JD_UTC)*pi/648000
 
     # Return the rotation.
     r_MOD_GCRF = rGCRFtoMOD_fk5(T, JD_TT)
@@ -376,8 +376,8 @@ function rECItoECI(T::Type,
     # Get the EOP data related to the desired epoch.
     #
     # TODO: The difference is small, but should it be `JD_TT` or `JD_UTC`?
-    δΔϵ_1980 = eop_data.dEps[JD_UTC]*pi/648000
-    δΔψ_1980 = eop_data.dPsi[JD_UTC]*pi/648000
+    δΔϵ_1980 = eop_data.dEps(JD_UTC)*pi/648000
+    δΔψ_1980 = eop_data.dPsi(JD_UTC)*pi/648000
 
     # In this case, we need to convert J2000 back to PEF and then convert to
     # MOD. This is necessary because we need to apply EOP corrections to convert
@@ -418,8 +418,8 @@ function rECItoECI(T::Type,
     # Get the EOP data related to the desired epoch.
     #
     # TODO: The difference is small, but should it be `JD_TT` or `JD_UTC`?
-    δΔϵ_1980 = eop_data.dEps[JD_UTC]*pi/648000
-    δΔψ_1980 = eop_data.dPsi[JD_UTC]*pi/648000
+    δΔϵ_1980 = eop_data.dEps(JD_UTC)*pi/648000
+    δΔψ_1980 = eop_data.dPsi(JD_UTC)*pi/648000
 
     # In this case, we need to convert J2000 back to PEF and then convert to
     # TOD. This is necessary because we need to apply EOP corrections to convert


### PR DESCRIPTION
`getindex(itp::AbstractInterpolation{T,N}, i::Vararg{Number,N}) where {T,N}` is deprecated in [`Interpolations.jl`](https://github.com/JuliaMath/Interpolations.jl/blob/eb5690069a8c5cbe97b6ac2e44f58ea1567bee8d/src/deprecations.jl) in favor of `itp(i...)`. This gets rid of all the warnings when testing.