### PR TITLE
💄 Return orbital elements from propagate!

### DIFF
--- a/src/analysis/eclipse_time.jl
+++ b/src/analysis/eclipse_time.jl
@@ -85,7 +85,7 @@ function eclipse_time_summary(JD₀::Number, a::Number, e::Number, i::Number,
     # Function to compute the lightning condition given an instant of the day
     # `t`, the day from orbit epoch `d`, and the Sun vector `s_i`.
     f(t,d,s_i)::Int = begin
-        r_i, ~ = propagate!(orbp, 86400d + t)
+        ~, r_i, ~ = propagate!(orbp, 86400d + t)
         return satellite_lighting_condition(r_i, s_i)
     end
 

--- a/src/analysis/ground_stations.jl
+++ b/src/analysis/ground_stations.jl
@@ -81,7 +81,7 @@ function ground_station_accesses(orbp, vrs_e::AbstractVector{T}, Δt::Number,
 
     # Lambda function to check if the ground station is visible.
     f(t)::Bool = begin
-        r_i, v_i   = propagate!(orbp, t)
+        ~, r_i, v_i   = propagate!(orbp, t)
         r_e        = r_eci_to_ecef(DCM, ECI, ECEF, JD₀ + t/86400, vargs...)*r_i
         visibility = [ground_station_visible(r_e, rs_e, θ) for rs_e in vrs_e]
 

--- a/src/analysis/ground_trace.jl
+++ b/src/analysis/ground_trace.jl
@@ -49,7 +49,7 @@ function ground_trace(orbp::OrbitPropagator, Δt::Number;
     t = 0:dt:Δt
 
     # Compute the points represented in the inertial reference frame.
-    r_i, ~ = propagate!(orbp_c, t)
+    ~, r_i, ~ = propagate!(orbp_c, t)
 
     # Get the epochs in Julian Day of each instant.
     JD = get_epoch(orbp) .+ t./86400

--- a/src/orbit/propagators/api/api.jl
+++ b/src/orbit/propagators/api/api.jl
@@ -71,9 +71,10 @@ function propagate!(orbp::OrbitPropagator{T}, t::AbstractVector) where T
         r_i_k, v_i_k = propagate!(orbp, t[k])
         result_r[k]  = r_i_k
         result_v[k]  = v_i_k
+        result_orb[k] = get_mean_elements(orbp)
     end
 
-    return result_r, result_v
+    return result_orb, result_r, result_v
 end
 
 """

--- a/test/orbit/propagators/sgp4.jl
+++ b/test/orbit/propagators/sgp4.jl
@@ -47,7 +47,7 @@
 
         # Propagate the orbit.
         t = SGP4_results[:,1]*60
-        r_TEME, v_TEME = propagate!(orbp, t)
+        ~, r_TEME, v_TEME = propagate!(orbp, t)
 
         # Compare the results.
         @inbounds for k = 1:length(t)

--- a/test/orbit/propagators/sgp4.jl
+++ b/test/orbit/propagators/sgp4.jl
@@ -82,7 +82,7 @@
 
     # Propagate the orbit.
     t = SGP4_results[:,1]   # [min.]
-    r_TEME, v_TEME = propagate_to_epoch!(orbp, tle[1].epoch .+ t/1440)
+    ~, r_TEME, v_TEME = propagate_to_epoch!(orbp, tle[1].epoch .+ t/1440)
 
     # Compare the results.
     @inbounds for k = 1:length(t)


### PR DESCRIPTION
Hi,

First of all thank you for your work on SatelliteToolbox, I've been using it for some time to simulate satellite orbits.

I noticed than in v0.9 the `propagate!` function no longer returns an array of orbital elements, yet on line 65 of `api.jl` you are creating the vector of `KeplerianElements` that would hold this output but never populate it. This pull request populates `result_orb` with the orbital elements at each time step using the new `get_mean_elements` function. I couldn't tell if you simply forgot to erase the line that allocates the result_orb array or if you added it because you intended to return it in the future. If it's the former then please close this PR.

I have tried to change all the calls to propagate to handle the new output. I have not updated the documentation but I will do so if you find this change useful.