### PR TITLE
Added milliseconds to date_to_jd(::DateTime).

### DIFF
--- a/src/time/julian_day.jl
+++ b/src/time/julian_day.jl
@@ -126,7 +126,7 @@ function date_to_jd(dateTime::DateTime)
                     Dates.day(dateTime),
                     Dates.hour(dateTime),
                     Dates.minute(dateTime),
-                    Dates.second(dateTime))
+                    Dates.second(dateTime) + Dates.millisecond(dateTime)/1000.0 )
 end
 
 """

--- a/test/time/time.jl
+++ b/test/time/time.jl
@@ -449,4 +449,10 @@ end
     JDdatetime = date_to_jd(DateTime(2020, 8, 14, 12, 4, 1))
     JDnums     = date_to_jd(2020, 8, 14, 12, 4, 1)
     @test JDdatetime == JDnums
+
+    JDdatetime_ms = date_to_jd(DateTime(2020, 8, 14, 12, 4, 1, 500))
+    JDnums_ms     = date_to_jd(2020, 8, 14, 12, 4, 1.5)
+    JDdatetime_back_ms = jd_to_date(DateTime,JDnums_ms)
+    @test JDdatetime_ms ≈ JDnums_ms atol=6e-9
+    @test JDdatetime_back_ms == DateTime(2020, 8, 14, 12, 4, 1, 500)
 end


### PR DESCRIPTION
Prior version of this function was ignoring milliseconds because
the smallest time unit passed to the date_to_jd(::Integer,...,
::Number) method was Dates.second(dateTime), which only provides
the whole second. This method takes seconds as a Number, so the
simple fix was adding " + Dates.millisecond(dateTime)/1000.0".