### PR TITLE
Remove @eval from @RemoteFile macro call

### DIFF
--- a/src/transformations/eop.jl
+++ b/src/transformations/eop.jl
@@ -137,8 +137,9 @@ function get_iers_eop_iau_1980(
     url::String = "https://datacenter.iers.org/data/csv/finals.all.csv";
     force_download = false
 )
-    _eop_iau1980 = @RemoteFile(
-        @eval($url),
+    @RemoteFile(
+        _eop_iau1980,
+        url,
         file="EOP_IAU1980.TXT",
         updates=:daily
     )
@@ -196,8 +197,9 @@ function get_iers_eop_iau_2000A(
     url::String = "https://datacenter.iers.org/data/csv/finals2000A.all.csv";
     force_download = false
 )
-    _eop_iau2000A = @RemoteFile(
-        @eval($url),
+    @RemoteFile(
+        _eop_iau2000A, 
+        url,
         file="EOP_IAU2000A.TXT",
         updates=:daily
     )


### PR DESCRIPTION
This should fix the way the `@RemoteFile` macro is called inside the `get_iers_eop` subfunctions to remove calls to the `@eval` macro.

The use of `@eval` is not needed since `@RemoteFile` has proper macro hygiene and also causes pre-compilation errors when using SatelliteToolbox as dependency and calling `get_iers_eop` in another Package, see issue https://github.com/JuliaSpace/SatelliteToolbox.jl/issues/75.

The use of `@eval` was put here probably because `@RemoteFile` has two signatures, one that takes a symbol as first argument (used to get the name of the variable name to assign the output to), and another that does not and simply return th output of the `RemoteFile` call.

Two possible solutions are possible:
1. Keep using the macro and switch to the correct version without `@eval`, giving the name `_eop_iau2000A` (or `_eop_iau1980`) as additional first argument. This may make the code a bit less clear as there is not a visible assignment to the variable
2. Directly skip the macro to keep the assignment clear in the code and use the underlying call to the `RemoteFile` function. This has the drawback that the directory where to download the file (which is automatically computed from the macro) has to be put in the code.

I chose the first approach here as it was the one with less friction, but I am willing to change this PR to use the 2nd approach.