### PR TITLE
:books: Fix typo for the altitude of geocentric_to_geodetic()

### DIFF
--- a/docs/src/man/transformations/geodetic_geocentric.md
+++ b/docs/src/man/transformations/geodetic_geocentric.md
@@ -78,7 +78,7 @@ function geocentric_to_geodetic(ϕ_gc::Number, r::Number)
 in which a tuple with two values will be returned:
 
 * The Geodetic latitude [rad]; and
-* The altitude about the reference ellipsoid (WGS-84) [m].
+* The altitude above the reference ellipsoid (WGS-84) [m].
 
 !!! note
 


### PR DESCRIPTION
The one of the returned tuple is the altitude *above* the reference ellipsoid, not about it.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>