### PR TITLE
Bump Interpolations to v0.14

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Crayons = "4.0"
-Interpolations = "~0.13.3"
+Interpolations = "0.14"
 OptionalData = "0.3, 1"
 Parameters = "0.12"
 PolynomialRoots = "1"

--- a/src/earth/space_indices/dtcfile.jl
+++ b/src/earth/space_indices/dtcfile.jl
@@ -24,7 +24,7 @@ Structure to store the interpolations of the data in `DTCFILE.TXT` file.
 
 """
 struct _DTCFILE_Structure
-    DstΔTc::_space_indices_itp_linear{Float64}
+    DstΔTc::_space_indices_itp_linear{Float64,Vector{Float64}}
 end
 
 # Remote file: DTCFILE.TXT

--- a/src/earth/space_indices/fluxtable.jl
+++ b/src/earth/space_indices/fluxtable.jl
@@ -10,8 +10,8 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 struct _fluxtable_Structure
-    F10obs::_space_indices_itp_constant{Float64}
-    F10adj::_space_indices_itp_constant{Float64}
+    F10obs::_space_indices_itp_constant{Float64,Vector{Float64}}
+    F10adj::_space_indices_itp_constant{Float64,Vector{Float64}}
 end
 
 # Remote file: fluxtable.txt

--- a/src/earth/space_indices/solfsmy.jl
+++ b/src/earth/space_indices/solfsmy.jl
@@ -35,14 +35,14 @@ Structure to store the interpolations of the data in `SOLFSMY.TXT` file.
 
 """
 struct _SOLFSMY_Structure
-    F10::_space_indices_itp_constant{Float64}
-    F81a::_space_indices_itp_constant{Float64}
-    S10::_space_indices_itp_constant{Float64}
-    S81a::_space_indices_itp_constant{Float64}
-    M10::_space_indices_itp_constant{Float64}
-    M81a::_space_indices_itp_constant{Float64}
-    Y10::_space_indices_itp_constant{Float64}
-    Y81a::_space_indices_itp_constant{Float64}
+    F10::_space_indices_itp_constant{Float64,Vector{Float64}}
+    F81a::_space_indices_itp_constant{Float64,Vector{Float64}}
+    S10::_space_indices_itp_constant{Float64,Vector{Float64}}
+    S81a::_space_indices_itp_constant{Float64,Vector{Float64}}
+    M10::_space_indices_itp_constant{Float64,Vector{Float64}}
+    M81a::_space_indices_itp_constant{Float64,Vector{Float64}}
+    Y10::_space_indices_itp_constant{Float64,Vector{Float64}}
+    Y81a::_space_indices_itp_constant{Float64,Vector{Float64}}
 end
 
 # Remote file: SOLFSMY.TXT

--- a/src/earth/space_indices/space_indices.jl
+++ b/src/earth/space_indices/space_indices.jl
@@ -10,18 +10,18 @@
 export get_space_index, init_space_indices
 
 # Interpolation types used in space indices.
-const _space_indices_itp_constant{T} = Interpolations.GriddedInterpolation{
-    T,
+const _space_indices_itp_constant{T1,T2} = Interpolations.GriddedInterpolation{
+    T1,
     1,
-    T,
+    T2,
     Gridded{Constant{Nearest, Throw{OnGrid}}},
     Tuple{Array{Float64,1}}
 }
 
-const _space_indices_itp_linear{T} = Interpolations.GriddedInterpolation{
-    T,
+const _space_indices_itp_linear{T1,T2} = Interpolations.GriddedInterpolation{
+    T1,
     1,
-    T,
+    T2,
     Gridded{Linear{Throw{OnGrid}}},
     Tuple{Array{Float64,1}}
 }

--- a/src/earth/space_indices/wdcfiles.jl
+++ b/src/earth/space_indices/wdcfiles.jl
@@ -29,8 +29,8 @@ Structure to store the interpolations of the data in WDC files.
 
 """
 struct _WDC_Structure
-    Kp::_space_indices_itp_constant{SVector{8,Float64}}
-    Ap::_space_indices_itp_constant{SVector{8,Float64}}
+    Kp::_space_indices_itp_constant{SVector{8,Float64},Vector{SVector{8,Float64}}}
+    Ap::_space_indices_itp_constant{SVector{8,Float64},Vector{SVector{8,Float64}}}
 end
 
 # Remote files: *.wdc


### PR DESCRIPTION
The [Interpolations](https://github.com/JuliaMath/Interpolations.jl) package has been at v0.14 since July 11. CompatHelper automatically opened #81, but v0.14 is breaking. This pull request bumps the compat entry for Interpolations to v0.14 and makes the necessary fixes to space_indices. 