### PR TITLE
Clear confusion about geomagnetic field vector

### DIFF
--- a/docs/src/man/earth/geomagnetic_field_models.md
+++ b/docs/src/man/earth/geomagnetic_field_models.md
@@ -28,7 +28,7 @@ The `igrf` function has the following signature:
 function igrf(date::Number, [r,h]::Number, λ::Number, Ω::Number, T[, P, dP]; max_degree = 13, show_warns = true)
 ```
 
-It computes the geomagnetic field vector [nT] at the date `date` [Year A.D.] and
+It computes the geomagnetic field vector (X, Y, and Z in nT) at the date `date` [Year A.D.] and
 position (`r`, `λ`, `Ω`).
 
 The position representation is defined by `T`. If `T` is `Val(:geocentric)`,


### PR DESCRIPTION
The input variables to these functions are date (i.e. year), radius (i.e. Z), latitude, and longitude (i.e. X and Y). There's no mention that the components of the returned geomagnetic field vector are X, Y, Z. While this might be an obvious convention, I had no idea and assumed that the order of the components would be the same as the order of the input variables to these functions (i.e. Z, X, Y). I tried to "fix" that with that tiny notation in the parenthesis, but maybe you have a better idea.

As a side note, it might be good to add functions for the magnetic components listed for example [here](https://www.geomag.nrcan.gc.ca/mag_fld/comp-en.php).